### PR TITLE
Refactors how tests are authenticated

### DIFF
--- a/tests/e2e/fixtures/extensions.ts
+++ b/tests/e2e/fixtures/extensions.ts
@@ -1,11 +1,13 @@
 import { Page, test as base } from '@playwright/test';
 import { authenticateOverAPI } from '../utils/authentication';
+import { userPassword, users } from '../utils/data';
 import { Locators } from './locators';
 import { extendPage } from './pageExtensions';
 import { TransactionDetail, TransactionRow } from './transactionList';
 
 type MyFixtures = {
-  authenticateOverAPI: (args: { username?: string; password?: string }) => Promise<void>;
+  user: { username: string; password: string };
+  startAuthenticated: boolean;
   page: Page;
   loc: Locators;
   transactionRow: TransactionRow;
@@ -13,13 +15,22 @@ type MyFixtures = {
 };
 
 const test = base.extend<MyFixtures>({
-  authenticateOverAPI: async ({ page, request, context }, use) => {
-    const authenticate = async (args: { username?: string; password?: string }) =>
-      authenticateOverAPI({ page, request, context, ...args });
-    await use(authenticate);
-  },
-  page: async ({ page }, use) => {
+  user: [
+    {
+      username: users.Heath93.username,
+      password: userPassword,
+    },
+    {
+      option: true,
+    },
+  ],
+  startAuthenticated: true,
+
+  page: async ({ page, request, context, user, startAuthenticated }, use) => {
     const extendedPage = extendPage(page);
+    if (startAuthenticated) {
+      await authenticateOverAPI({ page: extendedPage, request, context, ...user });
+    }
     await use(extendedPage);
   },
   loc: async ({ page }, use) => {

--- a/tests/e2e/fixtures/pageExtensions.ts
+++ b/tests/e2e/fixtures/pageExtensions.ts
@@ -29,5 +29,11 @@ export function extendPage(page: Page) {
     return await originalGoto(url, { waitUntil: 'commit', ...options });
   };
 
+  // Override the page.reload method to have option waitUntil: 'commit' by default to reduce test duration
+  const originalReload = page.reload.bind(page);
+  page.reload = async (options = {}) => {
+    return await originalReload({ waitUntil: 'commit', ...options });
+  };
+
   return page;
 }

--- a/tests/e2e/specs/login.spec.ts
+++ b/tests/e2e/specs/login.spec.ts
@@ -22,79 +22,79 @@ const loginCredentialsCombinations = [
 ];
 const displayedName = `${users.Heath93.firstName} ${users.Heath93.lastName[0]}`;
 
-test.beforeEach(async ({ page }) => {
-  await page.goto(homePageUrl);
+test.describe('Login Tests', () => {
+  test.use({ startAuthenticated: false });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(homePageUrl);
+  });
+
+  test('user can login', async ({ loc }) => {
+    await loc.usernameField.fill(users.Heath93.username);
+    await loc.passwordField.fill(userPassword);
+    await loc.loginButton.click();
+    await expect(loc.userBalance).toBeVisible();
+    await expect(loc.userFullName).toHaveText(displayedName);
+  });
+
+  test('invalid password is rejected', async ({ loc }) => {
+    const invalidPassword = 'invalid';
+    await loc.usernameField.fill(users.Heath93.username);
+    await loc.passwordField.fill(invalidPassword);
+    await loc.loginButton.click();
+    await expect(loc.failedLoginMessage).toHaveText('Username or password is invalid');
+  });
+
+  test('shows error when login requests fails', async ({ loc, page }) => {
+    await page.route(loginApiUrl, route => route.fulfill({ status: 500 }));
+    await loc.usernameField.fill(users.Heath93.username);
+    await loc.passwordField.fill(userPassword);
+    await loc.loginButton.click();
+    await expect(loc.failedLoginMessage).toHaveText('Username or password is invalid');
+  });
+
+  test('shows spinner when login requests takes longer', async ({ loc, page }) => {
+    await page.route(loginApiUrl, route => delayRoute(route, 2000));
+    await loc.usernameField.fill(users.Heath93.username);
+    await loc.passwordField.fill(userPassword);
+    await loc.loginButton.click();
+    //TODO: Verify spinner is visible (products does not have spinner yet)
+    // Without the spinner implementation this serves only as a demonstration of how to use delayedRoute
+    await page.waitForResponse(loginApiUrl);
+    await expect(loc.userBalance).toBeVisible();
+    await expect(loc.userFullName).toHaveText(displayedName);
+  });
+
+  test.describe('sign in button is disabled when', () => {
+    for (const cred of loginCredentialsCombinations) {
+      test(`${cred.testName}`, async ({ loc }) => {
+        await loc.usernameField.fill(cred.username);
+        await loc.passwordField.fill(cred.password);
+        await expect(loc.loginButton).toBeDisabled();
+      });
+    }
+  });
+
+  test('initially sign in button is enabled but login attempt is rejected', async ({ loc }) => {
+    await loc.loginButton.click();
+    await expect(loc.usernameHelp).toHaveText('Username is required');
+    await expect(loc.loginButton).toBeDisabled();
+  });
+
+  test('user can navigate sing up form', async ({ loc, page }) => {
+    await loc.signUpLink.click();
+    //TODO: Remove redundant second click once bug ABC-123 is fixed
+    await loc.signUpLink.click();
+    await expect(loc.signupHeader).toBeVisible();
+    expect(page.url()).toContain(signupPageUrl);
+  });
 });
 
-test('user can login via UI', async ({ loc }) => {
-  await loc.usernameField.fill(users.Heath93.username);
-  await loc.passwordField.fill(userPassword);
-  await loc.loginButton.click();
-  await expect(loc.userBalance).toBeVisible();
-  await expect(loc.userFullName).toHaveText(displayedName);
-});
-
-test('user can login via API', async ({ loc, authenticateOverAPI }) => {
-  await authenticateOverAPI({});
-  await expect(loc.userBalance).toBeVisible();
-  await expect(loc.userFullName).toHaveText(displayedName);
-});
-
-test('invalid password is rejected', async ({ loc }) => {
-  const invalidPassword = 'invalid';
-  await loc.usernameField.fill(users.Heath93.username);
-  await loc.passwordField.fill(invalidPassword);
-  await loc.loginButton.click();
-  await expect(loc.failedLoginMessage).toHaveText('Username or password is invalid');
-});
-
-test('shows error when login requests fails', async ({ loc, page }) => {
-  await page.route(loginApiUrl, route => route.fulfill({ status: 500 }));
-  await loc.usernameField.fill(users.Heath93.username);
-  await loc.passwordField.fill(userPassword);
-  await loc.loginButton.click();
-  await expect(loc.failedLoginMessage).toHaveText('Username or password is invalid');
-});
-
-test('shows spinner when login requests takes longer', async ({ loc, page }) => {
-  await page.route(loginApiUrl, route => delayRoute(route, 2000));
-  await loc.usernameField.fill(users.Heath93.username);
-  await loc.passwordField.fill(userPassword);
-  await loc.loginButton.click();
-  //TODO: Verify spinner is visible (products does not have spinner yet)
-  // Without the spinner implementation this serves only as a demonstration of how to use delayedRoute
-  await page.waitForResponse(loginApiUrl);
-  await expect(loc.userBalance).toBeVisible();
-  await expect(loc.userFullName).toHaveText(displayedName);
-});
-
-test.describe('sign in button is disabled when', () => {
-  for (const cred of loginCredentialsCombinations) {
-    test(`${cred.testName}`, async ({ loc }) => {
-      await loc.usernameField.fill(cred.username);
-      await loc.passwordField.fill(cred.password);
-      await expect(loc.loginButton).toBeDisabled();
-    });
-  }
-});
-
-test('initially sign in button is enabled but login attempt is rejected', async ({ loc }) => {
-  await loc.loginButton.click();
-  await expect(loc.usernameHelp).toHaveText('Username is required');
-  await expect(loc.loginButton).toBeDisabled();
-});
-
-test('user can logout', async ({ loc, authenticateOverAPI }) => {
-  await authenticateOverAPI({});
-  await loc.logoutButton.click();
-  await expect(loc.loginHeader).toBeVisible();
-  await expect(loc.userBalance).not.toBeVisible();
-});
-
-test('user can navigate sing up form', async ({ loc, page }) => {
-  await loc.signUpLink.click();
-  //TODO: Remove redundant second click once bug ABC-123 is fixed
-  await loc.signUpLink.click();
-  await expect(loc.signupHeader).toBeVisible();
-  expect(page.url()).toContain(signupPageUrl);
+test.describe('Logout Tests', () => {
+  test.use({ startAuthenticated: true });
+  test('user can logout', async ({ loc }) => {
+    await loc.logoutButton.click();
+    await expect(loc.loginHeader).toBeVisible();
+    await expect(loc.userBalance).not.toBeVisible();
+  });
 });

--- a/tests/e2e/specs/signup.spec.ts
+++ b/tests/e2e/specs/signup.spec.ts
@@ -107,7 +107,6 @@ const invalidInputCases = [
   // },
 ];
 
-// Disables the automatic authentication for this test file
 test.use({ startAuthenticated: false });
 
 test.beforeEach(async ({ page }) => {

--- a/tests/e2e/specs/signup.spec.ts
+++ b/tests/e2e/specs/signup.spec.ts
@@ -107,6 +107,9 @@ const invalidInputCases = [
   // },
 ];
 
+// Disables the automatic authentication for this test file
+test.use({ startAuthenticated: false });
+
 test.beforeEach(async ({ page }) => {
   await page.goto(signupPageUrl);
 });

--- a/tests/e2e/specs/transactions.spec.ts
+++ b/tests/e2e/specs/transactions.spec.ts
@@ -34,12 +34,7 @@ const expectElementCount = async (locator: Locator, comparisonMethod: 'toBeGreat
 };
 
 test.describe('Transactions list', () => {
-  test.beforeEach(async ({ page, authenticateOverAPI }) => {
-    await page.goto(homePageUrl);
-    await authenticateOverAPI({});
-  });
-
-  test('transaction list have infinite loading', async ({ loc }) => {
+  test.skip('transaction list have infinite loading', async ({ loc }) => {
     await expectElementCount(loc.transactionItem, 'toBeGreaterThan', 0);
     const initialTransactionCount = await loc.transactionItem.count();
     await loc.transactionItem.last().scrollIntoViewIfNeeded();
@@ -54,7 +49,7 @@ test.describe('Transactions list', () => {
         body: JSON.stringify(emptyTransactionsResponseData),
       });
     });
-    await page.goto(homePageUrl);
+    await page.reload();
     await expect(loc.noTransactionsMessage).toBeVisible();
     await expect(loc.transactionItem).not.toBeVisible();
     await expect(loc.createTransactionButton).toBeVisible();
@@ -62,7 +57,7 @@ test.describe('Transactions list', () => {
 
   test('transaction list shows list skeleton when data takes longer to load', async ({ page, loc }) => {
     await page.route(transactionsApiUrl, route => delayRoute(route, 2000));
-    await page.goto(homePageUrl);
+    await page.reload();
     await expect(loc.listSkeleton).toBeVisible();
     await expect(loc.grid).not.toBeVisible();
     await page.waitForResponse(transactionsApiUrl);
@@ -72,14 +67,14 @@ test.describe('Transactions list', () => {
 
   test('transaction list shows error when data fails to load', async ({ page, loc }) => {
     await page.route(transactionsApiUrl, route => route.fulfill({ status: 500 }));
-    await page.goto(homePageUrl);
+    await page.reload();
     //TODO: Bug ABC-123, once fixed change the verification to check for the error message
     await expect(loc.noTransactionsMessage).toBeVisible();
   });
 });
 
 test.describe('Transaction item', () => {
-  test.beforeEach(async ({ page, authenticateOverAPI }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto(homePageUrl);
     page.route(transactionsApiUrl, route => {
       route.fulfill({
@@ -88,9 +83,7 @@ test.describe('Transaction item', () => {
         body: JSON.stringify(transactionsResponseData),
       });
     });
-    const responsePromise = page.waitForResponse(transactionsApiUrl);
-    await authenticateOverAPI({});
-    await responsePromise;
+    await page.reload();
   });
 
   const testCases = [
@@ -133,9 +126,7 @@ test.describe('Transaction item', () => {
 });
 
 test.describe('Liking and commenting on a transaction', () => {
-  test.beforeEach(async ({ page, authenticateOverAPI, transactionDetail }, testInfo) => {
-    await page.goto(homePageUrl);
-    await authenticateOverAPI({ username: users.Heath93.username });
+  test.beforeEach(async ({ transactionDetail }, testInfo) => {
     const description = `${testInfo.title} ${new Date()}`;
     await transactionDetail.setupTransaction(users.Heath93.id, description);
     await transactionDetail.navigateTo();

--- a/tests/e2e/utils/authentication.ts
+++ b/tests/e2e/utils/authentication.ts
@@ -1,12 +1,13 @@
 import { APIRequestContext, APIResponse, BrowserContext, Page } from 'playwright/test';
-import { userPassword, users } from './data';
+import { homePageUrl } from '../fixtures/urls';
+import { userPassword } from './data';
 
 interface authenticateOverAPIOptions {
   page: Page;
   request: APIRequestContext;
   context: BrowserContext;
-  username?: string;
-  password?: string;
+  username: string;
+  password: string;
 }
 
 const createAuthData = async (loginResponse: APIResponse, username: string, password: string) => {
@@ -116,9 +117,10 @@ export const authenticateOverAPI = async ({
   page,
   request,
   context,
-  username = users.Heath93.username,
-  password = userPassword,
+  username,
+  password,
 }: authenticateOverAPIOptions) => {
+  await page.goto(homePageUrl);
   const loginResponse = await request.post('http://localhost:3001/login', {
     headers: { 'Content-Type': 'application/json' },
     data: JSON.stringify({ type: 'LOGIN', username, password }),
@@ -134,5 +136,5 @@ export const authenticateOverAPI = async ({
     localStorage.setItem('authState', authState);
   }, authState);
   await context.addCookies([{ name: 'connect.sid', value: sessionId, path: '/', domain: 'localhost' }]);
-  await page.reload({ waitUntil: 'commit' });
+  await page.reload();
 };


### PR DESCRIPTION
Refactoring API authentication
Authentication is called by default as part of page fixture.
Improves maitanability and allows in clear way to specify user or
whether test should start authenticated.